### PR TITLE
Mxs 1863 build mdbci

### DIFF
--- a/master/maxscale/builders/__init__.py
+++ b/master/maxscale/builders/__init__.py
@@ -8,6 +8,7 @@ from . import build_all
 from . import build_for_release
 from . import destroy
 from . import generate_and_sync_repod
+from . import build_mdbci
 
 MAXSCALE_BUILDERS = list(itertools.chain(
     build.BUILDERS,
@@ -19,4 +20,5 @@ MAXSCALE_BUILDERS = list(itertools.chain(
     build_and_test_snapshot.BUILDERS,
     destroy.BUILDERS,
     generate_and_sync_repod.BUILDERS,
+    build_mdbci.BUILDERS,
 ))

--- a/master/maxscale/builders/build_mdbci.py
+++ b/master/maxscale/builders/build_mdbci.py
@@ -22,7 +22,7 @@ def configureBuildProperties(properties):
 def remoteBuildMdbci():
     """This script will be run on the worker"""
     os.chdir("../build/package")
-    results = subprocess.run(["build.sh 1"])
+    results = subprocess.run(["./build.sh 1"], shell=True)
     sys.exit(results.returncode)
 
 

--- a/master/maxscale/builders/build_mdbci.py
+++ b/master/maxscale/builders/build_mdbci.py
@@ -22,7 +22,7 @@ def configureBuildProperties(properties):
 def remoteBuildMdbci():
     """This script will be run on the worker"""
     os.chdir("package")
-    results = subprocess.run(["build.sh"])
+    results = subprocess.run(["build.sh 1"])
     sys.exit(results.returncode)
 
 

--- a/master/maxscale/builders/build_mdbci.py
+++ b/master/maxscale/builders/build_mdbci.py
@@ -21,7 +21,7 @@ def configureBuildProperties(properties):
 
 def remoteBuildMdbci():
     """This script will be run on the worker"""
-    os.chdir("package")
+    os.chdir("../build/package")
     results = subprocess.run(["build.sh 1"])
     sys.exit(results.returncode)
 

--- a/master/maxscale/builders/build_mdbci.py
+++ b/master/maxscale/builders/build_mdbci.py
@@ -4,6 +4,7 @@ from buildbot.config import BuilderConfig
 from buildbot.plugins import util, steps
 from maxscale import workers
 from maxscale.builders.support import common, support
+from buildbot.steps.shell import ShellCommand
 
 ENVIRONMENT = {
     "JOB_NAME": util.Property("buildername"),
@@ -22,8 +23,15 @@ def configureBuildProperties(properties):
 def remoteBuildMdbci():
     """This script will be run on the worker"""
     os.chdir("../build/package")
-    results = subprocess.run(["./build.sh 1"], shell=True)
+    results = subprocess.run("./build.sh " + str(buildnumber), shell=True)
     sys.exit(results.returncode)
+
+
+def publishMdbci():
+    return [steps.ShellCommand(
+        name="Copy MDBCI AppImage to CI repository",
+        command=util.Interpolate("cp %(prop:builddir)s/build/package/build/out/* $HOME/%(prop:repo_path)s"),
+        alwaysRun=False)]
 
 
 def createBuildSteps():
@@ -32,8 +40,8 @@ def createBuildSteps():
     buildSteps.extend(common.cloneRepository())
     buildSteps.extend(support.executePythonScript(
         "Build MDBCI", remoteBuildMdbci))
+    buildSteps.extend(publishMdbci())
     buildSteps.extend(common.cleanBuildDir())
-    buildSteps.extend(common.destroyVirtualMachine())
     return buildSteps
 
 

--- a/master/maxscale/builders/build_mdbci.py
+++ b/master/maxscale/builders/build_mdbci.py
@@ -1,0 +1,57 @@
+import os
+
+from buildbot.config import BuilderConfig
+from buildbot.plugins import util, steps
+from maxscale import workers
+from maxscale.builders.support import common, support
+
+ENVIRONMENT = {
+    "JOB_NAME": util.Property("buildername"),
+    "BUILD_ID": util.Interpolate('%(prop:buildnumber)s'),
+    "BUILD_NUMBER": util.Interpolate('%(prop:buildnumber)s'),
+}
+
+
+@util.renderer
+def configureBuildProperties(properties):
+    return {
+        "mdbciConfig": util.Interpolate("%(prop:buildername)s-%(prop:buildnumber)s")
+    }
+
+
+def remoteBuildMdbci():
+    """This script will be run on the worker"""
+    os.chdir("package")
+    results = subprocess.run(["build.sh"])
+    sys.exit(results.returncode)
+
+
+def createBuildSteps():
+    buildSteps = []
+    buildSteps.append(steps.SetProperties(properties=configureBuildProperties))
+    buildSteps.extend(common.cloneRepository())
+    buildSteps.extend(support.executePythonScript(
+        "Build MDBCI", remoteBuildMdbci))
+    buildSteps.extend(common.cleanBuildDir())
+    buildSteps.extend(common.destroyVirtualMachine())
+    return buildSteps
+
+
+def createBuildFactory():
+    factory = util.BuildFactory()
+    buildSteps = createBuildSteps()
+    factory.addSteps(buildSteps)
+    return factory
+
+
+BUILDERS = [
+    BuilderConfig(
+        name="build_mdbci",
+        workernames=workers.workerNames(),
+        factory=createBuildFactory(),
+        nextWorker=common.assignWorker,
+        tags=["build"],
+        env=ENVIRONMENT,
+        collapseRequests=False,
+    )
+]

--- a/master/maxscale/builders/build_mdbci.py
+++ b/master/maxscale/builders/build_mdbci.py
@@ -30,7 +30,13 @@ def remoteBuildMdbci():
 def publishMdbci():
     return [steps.ShellCommand(
         name="Copy MDBCI AppImage to CI repository",
-        command=util.Interpolate("cp %(prop:builddir)s/build/package/build/out/* $HOME/%(prop:repo_path)s"),
+        command=util.Interpolate(
+            "cp %(prop:builddir)s/build/package/build/out/* \
+             $HOME/%(prop:repo_path)s; \
+             mdbci_file=`ls %(prop:builddir)s/build/package/build/out/* \
+             | xargs -n1 basename`; unlink $HOME/%(prop:repo_path)s/mdbci; \
+             ln -s $HOME/%(prop:repo_path)s/${mdbci_file} \
+             $HOME/%(prop:repo_path)s/mdbci"),
         alwaysRun=False)]
 
 

--- a/master/maxscale/builders/build_mdbci.py
+++ b/master/maxscale/builders/build_mdbci.py
@@ -64,7 +64,7 @@ BUILDERS = [
         workernames=workers.workerNames(),
         factory=createBuildFactory(),
         nextWorker=common.assignWorker,
-        tags=["build"],
+        tags=["build_mdbci"],
         env=ENVIRONMENT,
         collapseRequests=False,
     )

--- a/master/maxscale/config/constants.py
+++ b/master/maxscale/config/constants.py
@@ -74,6 +74,7 @@ DEFAULT_CMAKE_FLAGS = ('-DBUILD_TESTS=Y -DCMAKE_BUILD_TYPE=Debug -DFAKE_CODE=Y '
                        '-DWITH_ASAN=Y')
 
 MAXSCALE_REPOSITORY = 'https://github.com/mariadb-corporation/MaxScale.git'
+MDBCI_REPOSITORY = 'https://github.com/mariadb-corporation/mdbci.git'
 
 CI_SERVER_URL = 'http://max-tst-01.mariadb.com/ci-repository/'
 
@@ -88,5 +89,13 @@ MAXSCALE_CODEBASE = {
         "branch": "develop",
         "revision": "",
         "repository": MAXSCALE_REPOSITORY
+    },
+}
+
+MDBCI_CODEBASE = {
+    "": {
+        "branch": "integration",
+        "revision": "",
+        "repository": MDBCI_REPOSITORY
     },
 }

--- a/master/maxscale/schedulers/__init__.py
+++ b/master/maxscale/schedulers/__init__.py
@@ -8,6 +8,7 @@ from . import build_all
 from . import build_for_release
 from . import destroy
 from . import generate_and_sync_repod
+from . import build_mdbci
 
 
 MAXSCALE_SCHEDULERS = list(itertools.chain(
@@ -20,4 +21,5 @@ MAXSCALE_SCHEDULERS = list(itertools.chain(
     build_and_test_snapshot.SCHEDULERS,
     destroy.SCHEDULERS,
     generate_and_sync_repod.SCHEDULERS,
+    build_mdbci.SCHEDULERS,
 ))

--- a/master/maxscale/schedulers/build_mdbci.py
+++ b/master/maxscale/schedulers/build_mdbci.py
@@ -8,7 +8,7 @@ BUILD_PROPERTIES = [
 ]
 
 MANUAL_SCHEDULER = schedulers.ForceScheduler(
-    name="build_force",
+    name="build_mdbci_force",
     buttonName="Force build",
     builderNames=["build_mdbci"],
     codebases=properties.codebaseMdbciParameter(),

--- a/master/maxscale/schedulers/build_mdbci.py
+++ b/master/maxscale/schedulers/build_mdbci.py
@@ -1,0 +1,18 @@
+from buildbot.plugins import schedulers
+from maxscale.config import constants
+from . import properties
+
+BUILD_PROPERTIES = [
+    properties.repository_path(),
+    properties.host(),
+]
+
+MANUAL_SCHEDULER = schedulers.ForceScheduler(
+    name="build_force",
+    buttonName="Force build",
+    builderNames=["build_mdbci"],
+    codebases=properties.codebaseMdbciParameter(),
+    properties=BUILD_PROPERTIES
+)
+
+SCHEDULERS = [MANUAL_SCHEDULER]

--- a/master/maxscale/schedulers/properties.py
+++ b/master/maxscale/schedulers/properties.py
@@ -262,6 +262,20 @@ def codebaseParameter():
     )]
 
 
+def codebaseMdbciParameter():
+    return [util.CodebaseParameter(
+        "",
+        label="Main repository",
+        branch=util.StringParameter(name="branch",
+                                    default=constants.MDBCI_CODEBASE[""]["branch"]),
+        revision=util.FixedParameter(name="revision",
+                                     default=constants.MDBCI_CODEBASE[""]["revision"]),
+        project=util.FixedParameter(name="project", default=""),
+        repository=util.StringParameter(name="repository",
+                                        default=constants.MDBCI_CODEBASE[""]["repository"]),
+    )]
+
+
 def versionNumber():
     return util.StringParameter(
         name="version_number",


### PR DESCRIPTION
Add Builder for MDBCI'
currently it creates AppImage in max-tst-01.mariadb.com/ci-repository/ with build nu,ber as version number and links 'mdbci' file to the latest build (no possibility to put results to separate dir ('target'))