### PR TITLE
Use the subprocess check_output instead of run, and encode it to utf-…

### DIFF
--- a/master/maxscale/builders/run_test.py
+++ b/master/maxscale/builders/run_test.py
@@ -36,7 +36,6 @@ def configureCommonProperties(properties):
         "buildLogFile": util.Interpolate("%(prop:builddir)s/build_log_%(prop:buildnumber)s"),
         "resultFile": util.Interpolate("result_%(prop:buildnumber)s"),
         "jsonResultsFile": util.Interpolate("%(prop:builddir)s/json_%(prop:buildnumber)s"),
-        "leakSummaryResultsFile": util.Interpolate("%(prop:builddir)s/leak_summary_%(prop:buildnumber)s"),
         "mdbciConfig": util.Interpolate("%(prop:MDBCI_VM_PATH)s/%(prop:name)s")
     }
 

--- a/master/maxscale/builders/support/common.py
+++ b/master/maxscale/builders/support/common.py
@@ -397,7 +397,6 @@ def remoteParseCtestLogAndStoreIt():
                         "-o", os.path.join(builddir, "results_{}".format(buildnumber)),
                         "-r", "-f",
                         "-j", jsonResultsFile,
-                        "-l", leakSummaryResultsFile,
                         "-s", outputDirectory])
 
         storeDirectory = os.path.join(HOME, "LOGS", buildId, "LOGS")
@@ -462,7 +461,6 @@ def showTestResult(**kwargs):
         collectStdout=True,
         command=util.Interpolate(r"cat %(prop:builddir)s/results_%(prop:buildnumber)s "
                                  r"%(prop:builddir)s/coredumps_%(prop:buildnumber)s "
-                                 r"%(prop:builddir)s/leak_summary_%(prop:buildnumber)s 2>/dev/null "
                                  r"| sed -E 's/\\n\\//g'"),
         **kwargs)]
 


### PR DESCRIPTION
…8 (refs #25193)