### PR TITLE
Use DEFAULT_DAILY_TEST_CMAKE_FLAGS also for build_and_test_snapshot

### DIFF
--- a/master/maxscale/schedulers/build_and_test_snapshot.py
+++ b/master/maxscale/schedulers/build_and_test_snapshot.py
@@ -30,6 +30,7 @@ CHANGE_SOURCE_SCHEDULER = schedulers.SingleBranchScheduler(
     codebases=constants.MAXSCALE_CODEBASE,
     builderNames=["build_and_test_snapshot"],
     properties=DEFAULT_PROPERTIES
+    properties['cmake_flags'] = constants.DEFAULT_DAILY_TEST_CMAKE_FLAGS
 )
 
 MANUAL_SCHEDULER = schedulers.ForceScheduler(

--- a/master/maxscale/schedulers/build_and_test_snapshot.py
+++ b/master/maxscale/schedulers/build_and_test_snapshot.py
@@ -22,6 +22,7 @@ BUILD_AND_TEST_SNAPSHOT_PROPERTIES = [
 ] + COMMON_PROPERTIES
 
 DEFAULT_PROPERTIES = properties.extractDefaultValues(COMMON_PROPERTIES)
+DEFAULT_PROPERTIES['cmake_flags'] = constants.DEFAULT_DAILY_TEST_CMAKE_FLAGS
 
 CHANGE_SOURCE_SCHEDULER = schedulers.SingleBranchScheduler(
     name="build_and_test_snapshot_on_push",
@@ -30,7 +31,6 @@ CHANGE_SOURCE_SCHEDULER = schedulers.SingleBranchScheduler(
     codebases=constants.MAXSCALE_CODEBASE,
     builderNames=["build_and_test_snapshot"],
     properties=DEFAULT_PROPERTIES
-    properties['cmake_flags'] = constants.DEFAULT_DAILY_TEST_CMAKE_FLAGS
 )
 
 MANUAL_SCHEDULER = schedulers.ForceScheduler(


### PR DESCRIPTION
To avoid whole test run failure in case of internal Maxscale test failure
the build should be done with -DBUILD_TEST=N, i.e. using cmake_flags for daily tests